### PR TITLE
Extend options to support 'suppressErrors`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .env
-
+node_modules
 .tmp/
 dist/

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ $ yarn add webpack-sentry-plugin --dev
           organisation: 'your-organisation-name',
           project: 'your-project-name',
           apiKey: process.env.SENTRY_API_KEY,
-          
+
           // Release version name/hash is required
           release: function() {
             return process.env.GIT_SHA
@@ -50,6 +50,7 @@ $ yarn add webpack-sentry-plugin --dev
 #### Options
 
 - `exclude`: RegExp to match for excluded files
+- `suppressErrors`: Display warnings instead of failing webpack build - useful in case webpack compilation is done during deploy on multiple instances
 
 ```js
 var config = {

--- a/test/helpers/webpack.js
+++ b/test/helpers/webpack.js
@@ -43,6 +43,9 @@ export function runWebpack(config) {
 			if (stats.toJson().errors.length) {
 				reject({ errors: stats.toJson().errors })
 			}
+			if (stats.toJson().warnings.length) {
+				reject({ warnings: stats.toJson().warnings })
+			}
 			else {
 				resolve({ config, stats })
 			}

--- a/test/warnings.test.js
+++ b/test/warnings.test.js
@@ -1,0 +1,53 @@
+import { createWebpackConfig, runWebpack } from './helpers/webpack'
+
+it('adds warning if Sentry organisation slug is missing', () => {
+	return runWebpack(createWebpackConfig({ organisation: null, suppressErrors: true }))
+		.catch(({ warnings }) => {
+			expect(warnings).toHaveLength(1)
+			expect(warnings[0]).toEqual(
+				'Sentry Plugin: Error: Must provide organisation'
+			)
+		})
+})
+
+it('adds warning if Sentry project name is missing', () => {
+	return runWebpack(createWebpackConfig({ project: null, suppressErrors: true }))
+		.catch(({ warnings }) => {
+			expect(warnings).toHaveLength(1)
+			expect(warnings[0]).toEqual('Sentry Plugin: Error: Must provide project')
+		})
+})
+
+it('adds warning if Sentry api key is missing', () => {
+	return runWebpack(createWebpackConfig({ apiKey: null, suppressErrors: true }))
+		.catch(({ warnings }) => {
+			expect(warnings).toHaveLength(1)
+			expect(warnings[0]).toEqual('Sentry Plugin: Error: Must provide api key')
+		})
+})
+
+it('adds warning if release version is missing', () => {
+	return runWebpack(createWebpackConfig({ suppressErrors: true }))
+		.catch(({ warnings }) => {
+			expect(warnings).toHaveLength(1)
+			expect(warnings[0]).toEqual(
+				'Sentry Plugin: Error: Must provide release version'
+			)
+		})
+})
+
+it('adds release warning to compilation', () => {
+	return runWebpack(createWebpackConfig({ release: 'bad-release', suppressErrors: true }))
+		.catch(({ warnings }) => {
+			expect(warnings).toHaveLength(1)
+			expect(warnings[0]).toEqual('Sentry Plugin: Error: Release request error')
+		})
+})
+
+it('adds upload warning to compilation', () => {
+	return runWebpack(createWebpackConfig({ release: 'bad-upload', suppressErrors: true }))
+		.catch(({ warnings }) => {
+			expect(warnings).toHaveLength(1)
+			expect(warnings[0]).toEqual('Sentry Plugin: Error: Upload request error')
+		})
+})


### PR DESCRIPTION
Adds option to display warnings rather than throw errors. 
Useful in case webpack compilation is done during deploy on multiple instances and several workers may attempt to upload artefacts to the same release. 
Currently all but the first build would fail with HTTP response code 409 .