### PR TITLE
Pass the webpack hash to the releaseVersion function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ module.exports = class SentryPlugin {
 		this.projectSlug = options.project
 		this.apiKey = options.apiKey
 
-		this.releaseVersion = options.releaseVersion;
+		this.releaseVersion = options.release;
 
 		this.include = options.include
 		this.exclude = options.exclude
@@ -32,9 +32,9 @@ module.exports = class SentryPlugin {
 
 			const files = this.getFiles(compilation)
 
-	      	this.releaseVersion = _.isFunction(this.releaseVersion)
-	          ? this.releaseVersion(compilation.hash)
-	          : this.releaseVersion;
+			if (_.isFunction(this.releaseVersion)) {
+				this.releaseVersion(compilation.hash)
+			}
 
 			return this.createRelease()
 				.then(() => this.uploadFiles(files))

--- a/src/index.js
+++ b/src/index.js
@@ -13,9 +13,7 @@ module.exports = class SentryPlugin {
 		this.projectSlug = options.project
 		this.apiKey = options.apiKey
 
-		this.releaseVersion = _.isFunction(options.release)
-			? options.release()
-			: options.release
+		this.releaseVersion = options.releaseVersion;
 
 		this.include = options.include
 		this.exclude = options.exclude
@@ -33,6 +31,10 @@ module.exports = class SentryPlugin {
 			}
 
 			const files = this.getFiles(compilation)
+
+	      	this.releaseVersion = _.isFunction(this.releaseVersion)
+	          ? this.releaseVersion(compilation.hash)
+	          : this.releaseVersion;
 
 			return this.createRelease()
 				.then(() => this.uploadFiles(files))


### PR DESCRIPTION
We wanted to use the Webpack bundle hash as the sentry release. Something like:
![image](https://cloud.githubusercontent.com/assets/2373958/23513787/90f2a8ae-ff65-11e6-9f40-fe6e0353b06a.png)

I forked the repo and made the modification to be able to access the hash in the `release`.

This change will pass the hash to the release function. e.g. 
```js
new SentryPlugin({
  organisation: '<some organization>',
  project: '<some project>',
  apiKey: '<some api key>'
  release: (hash) => hash,
})
```

Maybe this is useful for someone else so here is the PR.

Thanks for this plugin btw, it's very handy. 