### PR TITLE
Make default transform work correctly

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ import fs from 'fs'
 
 const BASE_SENTRY_URL = 'https://sentry.io/api/0/projects'
 
-const DEFAULT_TRANSFORM = (filename) => filename
+const DEFAULT_TRANSFORM = (filename) => `~/${filename}`
 
 module.exports = class SentryPlugin {
 	constructor(options) {


### PR DESCRIPTION
I was using this without a transform, then realized you must have a site name, or a tilde in front of file names for them to be used! See this email: 

<img width="741" alt="screen shot 2017-03-07 at 8 47 48 pm" src="https://cloud.githubusercontent.com/assets/449136/23686400/6a1d174e-0377-11e7-98d7-42e365c40eac.png">

I went ahead and added it to the default transform, this way most people won't need to transform at all!