### PR TITLE
Add default include regex

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ module.exports = class SentryPlugin {
 			? options.release()
 			: options.release
 
-		this.include = options.include
+		this.include = options.include || /\.js$|\.map$/
 		this.exclude = options.exclude
 
 		this.filenameTransform = options.filenameTransform || DEFAULT_TRANSFORM


### PR DESCRIPTION
I don't see a reason anyone would want to include files other than `.js` or `.map`, so this removes the need to add this regex.