### PR TITLE
Support sourcemap headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "eslint-config-airbnb": "^13.0.0",
     "eslint-plugin-import": "^2.2.0",
     "jest": "^19.0.2",
+    "jest-matchers": "^19.0.0",
     "webpack": "^2.2.1"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -39,8 +39,11 @@
     "eslint": "^3.12.2",
     "eslint-config-airbnb": "^13.0.0",
     "eslint-plugin-import": "^2.2.0",
-    "webpack": "^1.14.0"
     "jest": "^19.0.2",
+    "webpack": "^2.2.1"
+  },
+  "peerDependencies": {
+    "webpack": "^2.2.1"
   },
   "jest": {
     "notify": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-sentry-plugin",
-  "version": "1.7.1",
+  "version": "2.0.0",
   "description": "Webpack plugin to upload source maps to Sentry",
   "keywords": [
     "sentry",

--- a/package.json
+++ b/package.json
@@ -39,14 +39,13 @@
     "eslint": "^3.12.2",
     "eslint-config-airbnb": "^13.0.0",
     "eslint-plugin-import": "^2.2.0",
-    "jest": "^17.0.3",
     "webpack": "^1.14.0"
+    "jest": "^19.0.2",
   },
   "jest": {
     "notify": true,
-    "testPathDirs": [
+    "roots": [
       "test"
-    ],
-    "mocksPattern": "test/mocks"
+    ]
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -2,12 +2,17 @@ import _ from 'lodash'
 import request from 'request-promise'
 import fs from 'fs'
 
+const ModuleFilenameHelpers = require('webpack/lib/ModuleFilenameHelpers')
+const SourceMapDevToolPlugin = require('webpack/lib/SourceMapDevToolPlugin')
+
 const BASE_SENTRY_URL = 'https://sentry.io/api/0/projects'
 
 const DEFAULT_TRANSFORM = (filename) => `~/${filename}`
 
 module.exports = class SentryPlugin {
 	constructor(options) {
+		this.options = options
+
 		this.baseSentryURL = options.baseSentryURL || BASE_SENTRY_URL
 		this.organisationSlug = options.organisation
 		this.projectSlug = options.project
@@ -20,11 +25,13 @@ module.exports = class SentryPlugin {
 
 		this.filenameTransform = options.filenameTransform || DEFAULT_TRANSFORM
 		this.suppressErrors = options.suppressErrors
+		this.sourceMapFilenameTemplate = null
 	}
 
 	apply(compiler) {
 		compiler.plugin('after-emit', (compilation, cb) => {
 			const errors = this.ensureRequiredOptions()
+			this.sourceMapFilenameTemplate = this.getSourcemapFilename(compilation)
 
 			if (errors) {
 				return this.handleErrors(errors, compilation, cb)
@@ -60,7 +67,7 @@ module.exports = class SentryPlugin {
 			return new Error('Must provide organisation')
 		}
 		else if (!this.projectSlug) {
-			return new Error(('Must provide project'))
+			return new Error('Must provide project')
 		}
 		else if (!this.apiKey) {
 			return new Error('Must provide api key')
@@ -73,19 +80,103 @@ module.exports = class SentryPlugin {
 		}
 	}
 
-	getFiles(compilation) {
-		return _.reduce(compilation.assets, (acc, asset, name) => {
-			return this.isIncludeOrExclude(name)
-				? acc.concat({ name, path: asset.existsAt })
-				: acc
-		}, [])
+	/**
+	 * Returns filenames and source map filenames
+	 * for the given chunk
+	*/
+	getFilesFromChunk(compilation, chunk) {
+		return chunk.files
+			.filter((filename) => ModuleFilenameHelpers.matchObject(this.options, filename))
+			.map((filenameWithQuery) => {
+				var filename = filenameWithQuery
+				var query = ''
+				var idx = filenameWithQuery.indexOf('?')
+				if (idx >= 0) {
+					query = filenameWithQuery.substr(idx)
+					filename = filenameWithQuery.substr(0, idx)
+				}
+
+				var sourceMapFilename
+				if (this.sourceMapFilenameTemplate) {
+					sourceMapFilename = compilation.getPath(this.sourceMapFilenameTemplate, {
+						chunk,
+						filename,
+						query,
+						basename: basename(filename),
+					})
+				}
+
+				return {
+					filename,
+					sourceMapFilename,
+				}
+			})
 	}
 
-	isIncludeOrExclude(filename) {
-		const isIncluded = this.include ? this.include.test(filename) : true
-		const isExcluded = this.exclude ? this.exclude.test(filename) : false
+	/**
+	 * Returns the filename template (e.g. [file].map) for sourcemaps.
+	 * If sourcemaps are disabled, it returns null;
+	 * @param {*} compilation
+	 */
+	getSourcemapFilename(compilation) {
+		/**
+		 * Gets the sourcemap filename from (prio hight to low):
+		 * - This plugins' options.sourceMapFilename
+		 * - SourceMapDevToolPlugin if present
+		 * - webpack.config.output.sourceMapFilename
+		 */
 
-		return isIncluded && !isExcluded
+		if (this.options.sourceMapFilename) {
+			return this.options.sourceMapFilename
+		}
+
+		const devtoolPlugin = compilation.options.plugins.find(
+			(plugin) => plugin instanceof SourceMapDevToolPlugin,
+		)
+		if (devtoolPlugin && devtoolPlugin.sourceMapFilename) {
+			return devtoolPlugin.sourceMapFilename
+		}
+
+		return compilation.outputOptions.sourceMapFilename
+	}
+
+	// This function works in the same way that https://github.com/webpack/webpack/blob/master/lib/SourceMapDevToolPlugin.js does
+	getFiles(compilation) {
+		const chunks = compilation.chunks
+
+		// Get all files in chunks and corresponding source map filenames.
+		const files = chunks.reduce(
+			(filesFlattened, chunk) => {
+				return filesFlattened.concat(this.getFilesFromChunk(compilation, chunk))
+			},
+			[],
+		)
+
+		// Get asset paths
+		return files.map((file) => {
+			const fileAsset = compilation.assets[file.filename]
+			if (!fileAsset || !fileAsset.existsAt) {
+				compilation.warnings.push(`Sentry Plugin: Asset for ${file.filename} not found`)
+			}
+
+			if (file.sourceMapFilename && compilation.assets[file.sourceMapFilename]) {
+				if (!compilation.assets[file.sourceMapFilename].existsAt) {
+					compilation.warnings.push(`Sentry Plugin: Asset for ${file.sourceMapFilename} not found`)
+				}
+
+				return {
+					name: file.filename,
+					path: fileAsset.existsAt,
+					sourceMapName: file.sourceMapFilename,
+					sourceMapPath: compilation.assets[file.sourceMapFilename].existsAt,
+				}
+			}
+
+			return {
+				name: file.filename,
+				path: fileAsset.existsAt,
+			}
+		})
 	}
 
 	createRelease() {
@@ -93,34 +184,46 @@ module.exports = class SentryPlugin {
 			url: `${this.sentryReleaseUrl()}/`,
 			method: 'POST',
 			auth: {
-				bearer: this.apiKey
+				bearer: this.apiKey,
 			},
 			headers: {
-				'Content-Type': 'application/json'
+				'Content-Type': 'application/json',
 			},
-			body: JSON.stringify({ version: this.releaseVersion })
+			body: JSON.stringify({ version: this.releaseVersion }),
 		})
 	}
 
-	uploadFiles(files) {
-		return Promise.all(files.map(this.uploadFile.bind(this)))
-	}
-
-	uploadFile({ path, name }) {
+	uploadFile({ path, name, headers }) {
 		return request({
 			url: `${this.sentryReleaseUrl()}/${this.releaseVersion}/files/`,
 			method: 'POST',
 			auth: {
-				bearer: this.apiKey
+				bearer: this.apiKey,
 			},
 			formData: {
 				file: fs.createReadStream(path),
-				name: this.filenameTransform(name)
-			}
+				name: this.filenameTransform(name),
+			},
+			headers,
 		})
+	}
+
+	uploadFiles(files) {
+		return Promise.all(files.map((file) => {
+			const headers = file.sourceMapName ? {
+				sourcemap: file.sourceMapName
+			} : {}
+
+			return this.uploadFile(Object.assign(file, {headers}))
+		}))
 	}
 
 	sentryReleaseUrl() {
 		return `${this.baseSentryURL}/${this.organisationSlug}/${this.projectSlug}/releases`
 	}
+}
+
+function basename(name) {
+	if (name.indexOf('/') < 0) return name
+	return name.substr(name.lastIndexOf('/') + 1)
 }

--- a/src/index.js
+++ b/src/index.js
@@ -194,7 +194,7 @@ module.exports = class SentryPlugin {
 	}
 
 	uploadFile({ path, name, headers, headerStr }) {
-		let requestObj = {
+		const requestObj = {
 			url: `${this.sentryReleaseUrl()}/${this.releaseVersion}/files/`,
 			method: 'POST',
 			auth: {
@@ -205,13 +205,13 @@ module.exports = class SentryPlugin {
 				name: this.filenameTransform(name),
 			},
 			headers,
-		};
+		}
 
 		if (headerStr) {
 			requestObj.formData.header = headerStr
 		}
 
-		return request(requestObj);
+		return request(requestObj)
 	}
 
 	uploadFiles(files) {
@@ -219,7 +219,7 @@ module.exports = class SentryPlugin {
 			const headers = file.sourceMapName ? {
 				sourcemap: file.sourceMapName
 			} : {}
-			const headerStr = file.sourceMapName ? ("sourcemap:" + file.sourceMapName) : null
+			const headerStr = file.sourceMapName ? `sourcemap:${file.sourceMapName}` : null
 
 			return this.uploadFile(Object.assign(file, {headers, headerStr}))
 		}))

--- a/src/index.js
+++ b/src/index.js
@@ -193,8 +193,8 @@ module.exports = class SentryPlugin {
 		})
 	}
 
-	uploadFile({ path, name, headers }) {
-		return request({
+	uploadFile({ path, name, headers, headerStr }) {
+		let requestObj = {
 			url: `${this.sentryReleaseUrl()}/${this.releaseVersion}/files/`,
 			method: 'POST',
 			auth: {
@@ -205,7 +205,13 @@ module.exports = class SentryPlugin {
 				name: this.filenameTransform(name),
 			},
 			headers,
-		})
+		};
+
+		if (headerStr) {
+			requestObj.formData.headers = headerStr
+		}
+
+		return request(requestObj);
 	}
 
 	uploadFiles(files) {
@@ -213,8 +219,9 @@ module.exports = class SentryPlugin {
 			const headers = file.sourceMapName ? {
 				sourcemap: file.sourceMapName
 			} : {}
+			const headerStr = file.sourceMapName ? ("sourcemap:" + file.sourceMapName) : null
 
-			return this.uploadFile(Object.assign(file, {headers}))
+			return this.uploadFile(Object.assign(file, {headers, headerStr}))
 		}))
 	}
 

--- a/src/index.js
+++ b/src/index.js
@@ -208,7 +208,7 @@ module.exports = class SentryPlugin {
 		};
 
 		if (headerStr) {
-			requestObj.formData.headers = headerStr
+			requestObj.formData.header = headerStr
 		}
 
 		return request(requestObj);

--- a/test/__mocks__/request-promise.js
+++ b/test/__mocks__/request-promise.js
@@ -1,10 +1,12 @@
 const responses = {
 	release: {
 		'bad-release': () => Promise.reject(new Error('Release request error')),
-		'bad-upload': () => Promise.resolve()
+		'bad-upload': () => Promise.resolve(),
+		'successful-upload': () => Promise.resolve()
 	},
 	upload: {
-		'bad-upload': () => Promise.reject(new Error('Upload request error'))
+		'bad-upload': () => Promise.reject(new Error('Upload request error')),
+		'successful-upload': () => Promise.resolve()
 	}
 }
 

--- a/test/__mocks__/request-promise.js
+++ b/test/__mocks__/request-promise.js
@@ -23,6 +23,7 @@ function mockRequestPromise({ url, body }) {
 			return responses.upload[version]()
 		}
 	}
+	return Promise.reject(new Error("Mock: Unknown"));
 }
 /* eslint-enable consistent-return */
 

--- a/test/headers.test.js
+++ b/test/headers.test.js
@@ -50,6 +50,9 @@ describe('uploading with correct headers', () => {
                     .toHaveBeenCalledWithObject({
                         headers: {
                             sourcemap: 'index.bundle.js.map'
+                        },
+                        formData: {
+                            header: 'sourcemap:index.bundle.js.map'
                         }
                     });
 			})
@@ -63,6 +66,9 @@ describe('uploading with correct headers', () => {
                     .toHaveBeenCalledWithObject({
                         headers: {
                             sourcemap: 'index.bundle.js.map'
+                        },
+                        formData: {
+                            header: 'sourcemap:index.bundle.js.map'
                         }
                     });
 			})
@@ -80,7 +86,10 @@ describe('uploading with correct headers', () => {
 				expect(request.default)
                     .toHaveBeenCalledWithObject({
                         headers: {
-                            sourcemap: 'renamed-the-sourcemap.map'
+                            sourcemap: 'renamed-the-sourcemap.map',
+                        },
+                        formData: {
+                            header: 'sourcemap:renamed-the-sourcemap.map'
                         }
                     });
 			})
@@ -97,6 +106,9 @@ describe('uploading with correct headers', () => {
                     .toHaveBeenCalledWithObject({
                         headers: {
                             sourcemap: 'renamed-the-sourcemap.map'
+                        },
+                        formData: {
+                            header: 'sourcemap:renamed-the-sourcemap.map'
                         }
                     });
 			})

--- a/test/headers.test.js
+++ b/test/headers.test.js
@@ -1,0 +1,104 @@
+import { createWebpackConfig, runWebpack } from './helpers/webpack'
+import {
+	expectNoFailure,
+} from './helpers/assertion'
+const _ = require('lodash')
+const matchers = require('jest-matchers/build/matchers');
+const SourceMapDevToolPlugin = require('webpack/lib/SourceMapDevToolPlugin')
+
+expect.extend({
+    toHaveBeenCalledWithObject(received, argument) {
+        if (received.mock.calls.length == 0) {
+            return {
+                message: () => "Function has not been called",
+                pass: false
+            }
+        }
+
+        const passed = _.some(received.mock.calls, (args) => {
+            if (!args[0]) {
+                return false;
+            }
+
+            let match = matchers.toMatchObject(
+                args[0],
+                argument
+            );
+            return match.pass;
+        })
+
+        return {
+            message: () => ("Arguments did not match the template"),
+            pass: passed
+        }
+    }
+})
+
+describe('uploading with correct headers', () => {
+	const release = 'successful-upload'
+    const request = require('request-promise')
+
+	beforeEach(() => {
+		request.default.mockClear();
+	})
+
+	it('uploads source with correct headers with devtool: hidden-source-map', () => {
+		return runWebpack(createWebpackConfig({ release }, { devtool: 'hidden-source-map'}))
+			.then(() => {
+				const mock = request.default.mock;
+				expect(request.default)
+                    .toHaveBeenCalledWithObject({
+                        headers: {
+                            sourcemap: 'index.bundle.js.map'
+                        }
+                    });
+			})
+	})
+
+    it('uploads source with correct headers with devtool: source-map', () => {
+		return runWebpack(createWebpackConfig({ release }, { devtool: 'source-map'}))
+			.then(() => {
+				const mock = request.default.mock;
+				expect(request.default)
+                    .toHaveBeenCalledWithObject({
+                        headers: {
+                            sourcemap: 'index.bundle.js.map'
+                        }
+                    });
+			})
+	})
+
+    it('uploads source with correct headers with SourceMapDevToolPlugin', () => {
+        const webpackConfig = createWebpackConfig({ release });
+        delete webpackConfig.devtool;
+        webpackConfig.plugins.push(new SourceMapDevToolPlugin({
+            filename: 'renamed-the-sourcemap.map'
+        }));
+		return runWebpack(webpackConfig)
+			.then(() => {
+				const mock = request.default.mock;
+				expect(request.default)
+                    .toHaveBeenCalledWithObject({
+                        headers: {
+                            sourcemap: 'renamed-the-sourcemap.map'
+                        }
+                    });
+			})
+	})
+
+    it('uploads source with correct headers with output.sourceMapFilename', () => {
+        const webpackConfig = createWebpackConfig({ release });
+        webpackConfig.output.sourceMapFilename = 'renamed-the-sourcemap.map';
+        
+		return runWebpack(webpackConfig)
+			.then(() => {
+				const mock = request.default.mock;
+				expect(request.default)
+                    .toHaveBeenCalledWithObject({
+                        headers: {
+                            sourcemap: 'renamed-the-sourcemap.map'
+                        }
+                    });
+			})
+	})
+})


### PR DESCRIPTION
When using hidden sourcemaps (devtool: hidden-source-map) Sentry requires a HTTP header ("sourcemap") to be sent with each request. This way the sourcemaps can be referenced even without a sourcemap comment.

I have updated the plugin to support this functionality. I've had some errors with jest, which is why i updated jest as well. Also updated webpack to the now stable 2.2.1 and bumped the version of this plugin to reflect the change.