### PR TITLE
Add `suppressConflictError` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,9 @@ $ yarn add webpack-sentry-plugin --dev
   }
   ```
 
-- `suppressErrors`: Display warnings instead of failing webpack build - useful in case webpack compilation is done during deploy on multiple instances
+- `suppressErrors`: Display warnings instead of failing webpack build
+
+- `suppressConflictError`: Similar to `suppressErrors`, but only supresses release conflict errors - useful in case webpack compilation is done during deploy on multiple instances
 
 - `baseSentryURL`: URL of Sentry instance. Shouldn't need to set if using sentry.io, but useful if self hosting
 

--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,7 @@ module.exports = class SentryPlugin {
 
     this.filenameTransform = options.filenameTransform || DEFAULT_TRANSFORM
     this.suppressErrors = options.suppressErrors
+    this.suppressConflictError = options.suppressConflictError
 
     this.deleteAfterCompile = options.deleteAfterCompile
     this.deleteRegex = options.deleteRegex || DEFAULT_DELETE_REGEX
@@ -55,7 +56,10 @@ module.exports = class SentryPlugin {
 
   handleErrors(err, compilation, cb) {
     const errorMsg = `Sentry Plugin: ${err}`
-    if (this.suppressErrors) {
+    if (
+      this.suppressErrors ||
+      (this.suppressConflictError && err.statusCode === 409)
+    ) {
       compilation.warnings.push(errorMsg)
     }
     else {


### PR DESCRIPTION
Allow conflict errors to be suppressed, but still fail build on all other errors.

Closes #17