### PR TITLE
Extend webpack peer dependency range to include v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "webpack": "^2.3.0"
   },
   "peerDependencies": {
-    "webpack": "^1.14.0 || ^2.2.0"
+    "webpack": "^1.14.0 || >=2.2.0 <4.0.0"
   },
   "jest": {
     "notify": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-sentry-plugin",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "description": "Webpack plugin to upload source maps to Sentry",
   "keywords": [
     "sentry",


### PR DESCRIPTION
I haven't had any issues with this package in webpack 3 and I'm not aware of anything in its breaking changes that would cause issues, so I think a version range expansion is reasonable so folks stop getting warnings.

Feel free to let me know if you'd prefer a stricter range (such as `^1.14.0 || ^2.2.0 || ^3.4.0` and I'll be happy to change it accordingly.