### PR TITLE
Update Sentry endpoint to /organizations/:id/releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ $ yarn add webpack-sentry-plugin --dev
 
 - `organization`: **Required**, Sentry organization to upload files to
 
-- `project`: **Required**, Sentry project to upload files to
+- `project`: **Required**, Sentry project(s) to upload files to. Can be a string project slug or an array of project slugs if the release should be associated with multiple projects.
 
 - `apiKey`: **Required**, Sentry api key ([Generate one here](https://sentry.io/api/), ensure that `project:write`, `project:read` and `project:releases` are selected ,under scopes)
 


### PR DESCRIPTION
The [documented endpoint](https://docs.sentry.io/api/releases/post-organization-releases/) to create a release in Sentry is `/api/0/organizations/{organization_slug}/releases/`. I actually can no longer find documentation for the one that webpack-sentry-plugin currently uses (`/api/0/{organization_slug}/{project_slug}/releases/`); I assume it was removed from the documentation but continues to be supported for legacy purposes.

This is mostly important for release commits. I had a back-and-forth with Sentry support and determined that the `project_slug` endpoint does not work for creating release commits, only the documented "new" endpoint.

Also, the new endpoint allows creating a release in multiple projects at the same time, via an array of project slugs. I added a `projects` option that accepts an array, and falls back to `[options.project]` for backwards compatibility.

Let me know if anything's unclear or needs work 🙂 

Closes #38 