### PR TITLE
Allow providing additional passthrough options for the request library.

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ $ yarn add webpack-sentry-plugin --dev
 
 - `deleteAfterCompile`: Boolean determining whether source maps should be deleted after the webpack compile finishes. Defaults to `false`
 
+- `requestOptions`: Object of options passed through to the underlying `request` call; see the [request library documentation](https://github.com/request/request#requestoptions-callback) for available options.
+
 ### What is a `release`?
 
 A release is a concept that Sentry uses to attach source maps to a known version of your code. The plugin creates one for you, but you need to provide a "name" for a particular version of your code, which is just a string. Sentry can then use the release to say that a it found an error in this known version of your code. 

--- a/src/index.js
+++ b/src/index.js
@@ -47,6 +47,7 @@ module.exports = class SentryPlugin {
     this.filenameTransform = options.filenameTransform || DEFAULT_TRANSFORM
     this.suppressErrors = options.suppressErrors
     this.suppressConflictError = options.suppressConflictError
+    this.requestOptions = options.requestOptions || {}
 
     this.deleteAfterCompile = options.deleteAfterCompile
     this.deleteRegex = options.deleteRegex || DEFAULT_DELETE_REGEX
@@ -137,8 +138,12 @@ module.exports = class SentryPlugin {
     return isIncluded && !isExcluded
   }
 
+  combineRequestOptions(req) {
+    return Object.assign({}, this.requestOptions, req)
+  }
+
   createRelease() {
-    return request({
+    return request(this.combineRequestOptions({
       url: `${this.sentryReleaseUrl()}/`,
       method: 'POST',
       auth: {
@@ -148,7 +153,7 @@ module.exports = class SentryPlugin {
         'Content-Type': 'application/json',
       },
       body: JSON.stringify(this.releaseBody),
-    })
+    }))
   }
 
   uploadFiles(files) {
@@ -156,7 +161,7 @@ module.exports = class SentryPlugin {
   }
 
   uploadFile({ path, name }) {
-    return request({
+    return request(this.combineRequestOptions({
       url: `${this.sentryReleaseUrl()}/${this.releaseVersion}/files/`,
       method: 'POST',
       auth: {
@@ -166,7 +171,7 @@ module.exports = class SentryPlugin {
         file: fs.createReadStream(path),
         name: this.filenameTransform(name),
       },
-    })
+    }))
   }
 
   sentryReleaseUrl() {

--- a/src/index.js
+++ b/src/index.js
@@ -139,7 +139,14 @@ module.exports = class SentryPlugin {
   }
 
   combineRequestOptions(req) {
-    return Object.assign({}, this.requestOptions, req)
+    const combined = Object.assign({}, this.requestOptions, req)
+    if (this.requestOptions.headers) {
+      Object.assign(combined.headers, this.requestOptions.headers, req.headers)
+    }
+    if (this.requestOptions.auth) {
+      Object.assign(combined.auth, this.requestOptions.auth, req.auth)
+    }
+    return combined
   }
 
   createRelease() {


### PR DESCRIPTION
#30 wanted a configuration option for `strictSSL` on the `request` library (which `webpack-sentry-plugin` uses under the hood). I figured better to solve the general case and add a config parameter for options to be sent to the underlying `request`.

Fixes #30