### PR TITLE
Add `removeSourceMapUrlsAfterCompile` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ var config = {
 
 - `deleteAfterCompile`: Boolean determining whether source maps should be deleted on the build server after the webpack compile finishes. Defaults to `false`
 
+- `removeSourceMapUrlsAfterCompile`: Boolean determining whether source map urls be removed on the build server after the webpack compile finishes. Defaults to `false`
+
 - `createReleaseRequestOptions`: Object of options or function returning object of options passed through to the underlying `request` call on release creating; see the [request library documentation](https://github.com/request/request#requestoptions-callback) for available options.
   - If a function is provided, it is given one argument: req, an object of options (including url, auth, and body) that the plugin is sending to the underlying request call. (This is useful if you want to configure the request dynamically based on request data such as the filename.)
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -120,4 +120,19 @@ describe('uploading files to Sentry release', () => {
         fs.existsSync(path.join(OUTPUT_PATH, 'index.bundle.js.map')),
       ).toEqual(false)
     }))
+
+  it('removes source map urls after compilation', () =>
+    runWebpack(
+      createWebpackConfig({
+        release,
+        removeSourceMapUrlsAfterCompile: true,
+      }),
+    ).then(() => {
+      expect(
+        fs
+          .readFileSync(path.join(OUTPUT_PATH, 'index.bundle.js'))
+          .toString()
+          .match(/\n\/\/# sourceMappingURL=[^\n]+$/),
+      ).toEqual(null)
+    }))
 })


### PR DESCRIPTION
Removes `//# sourceMappingURL=…` line after compilation

Use-case:
1. webpack devtool is set to `source-map`
1. uploaded generated assets and source maps to Sentry (using this plugin)
1. enabled `deleteAfterCompile` option to remove files before deploy
1. enabled `removeSourceMapUrlsAfterCompile` option to remove the leftover `//# sourceMappingURL=…` lines (avoiding 404)