### PR TITLE
Only run nps build in prepublish.

### DIFF
--- a/package-scripts.js
+++ b/package-scripts.js
@@ -6,7 +6,7 @@ module.exports = {
     },
     prepublish: {
       description: 'Validate and build before release',
-      script: 'nps validate && nps build'
+      script: 'nps build'
     },
     validate: {
       description: 'Runs code formatting, linting and tests',


### PR DESCRIPTION
Validation is handled by CI, and it requires a bunch of setup locally.