### PR TITLE
Mention Webpack 4 support in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/40thieves/webpack-sentry-plugin.svg?branch=master)](https://travis-ci.org/40thieves/webpack-sentry-plugin)
 
-A webpack (1, 2, or 3) plugin to upload source maps to [Sentry](https://sentry.io/).
+A webpack (1, 2, 3 or 4) plugin to upload source maps to [Sentry](https://sentry.io/).
 
 ### Installation
 


### PR DESCRIPTION
Webpack 4 support was introduced in https://github.com/40thieves/webpack-sentry-plugin/pull/59 and released in 1.15.0 on npm registry.

It would be good to release `1.15.0` as a git tag and GitHub release as well.