### PR TITLE
fix: uploaded files wrong when compiler.options.output.filename confi…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
 language: node_js
 node_js:
   - "node"
+script:
+  - yarn lint
+  - yarn test

--- a/src/index.js
+++ b/src/index.js
@@ -87,7 +87,7 @@ module.exports = class SentryPlugin {
         return
       }
 
-      const files = this.getFiles(compiler, compilation)
+      const files = this.getFiles(compilation)
 
       if (typeof this.releaseVersion === 'function') {
         this.releaseVersion = this.releaseVersion(compilation.hash)
@@ -111,7 +111,7 @@ module.exports = class SentryPlugin {
 
     compiler.hooks.done.tapPromise('SentryPlugin', async (stats) => {
       if (this.deleteAfterCompile) {
-        await this.deleteFiles(compiler, stats)
+        await this.deleteFiles(stats)
       }
     })
   }
@@ -147,12 +147,11 @@ module.exports = class SentryPlugin {
     }
   }
 
-  getFiles(compiler, compilation) {
+  getFiles(compilation) {
     return Object.keys(compilation.assets)
       .map((name) => {
         if (this.isIncludeOrExclude(name)) {
-          const filePath = path.join(compiler.options.output.path, name)
-          return { name, filePath }
+          return { name, filePath: compilation.assets[name].existsAt }
         }
         return null
       })
@@ -236,11 +235,11 @@ module.exports = class SentryPlugin {
     }/releases`
   }
 
-  async deleteFiles(compiler, stats) {
+  async deleteFiles(stats) {
     Object.keys(stats.compilation.assets)
       .filter(name => this.deleteRegex.test(name))
       .forEach((name) => {
-        const filePath = path.join(compiler.options.output.path, name)
+        const filePath = stats.compilation.assets[name].existsAt
         fs.unlinkSync(filePath)
       })
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,4 @@
 import request from 'request-promise'
-import path from 'path'
 import fs from 'fs'
 import PromisePool from 'es6-promise-pool'
 


### PR DESCRIPTION
uploaded files wrong when `compiler.options.output.filename` was configured as `js/[name].js?[hash:10]` with **query**

 **Error**: `ERROR in Sentry Plugin: RequestError: Error: form-data: ENOENT: no such file or directory, open 'path/to/bundle.js?f24a9dd369'`

**Why**: because SentryPlugin uses the **key** of `compilation.assets` as filename, but webpack uses the name without query as filename, so we can not found the file

**Resolve**: use `compilation.assets[name].existsAt` as the `filePath`