### PR TITLE
Add sanity check before removing source maps

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -243,8 +243,12 @@ module.exports = class SentryPlugin {
           fs.unlinkSync(filePath)
         }
         else {
-          console.warn(`WebpackSentryPlugin: unable to delete ${name} - ` +
-            'probably the file was not created due to an error in the build')
+          // eslint-disable-next-line no-console
+          console.warn(
+            `WebpackSentryPlugin: unable to delete '${name}'. ` +
+              'File does not exist; it may not have been created ' +
+              'due to a build error.'
+          )
         }
       })
   }

--- a/src/index.js
+++ b/src/index.js
@@ -239,7 +239,13 @@ module.exports = class SentryPlugin {
       .filter(name => this.deleteRegex.test(name))
       .forEach((name) => {
         const filePath = stats.compilation.assets[name].existsAt
-        fs.unlinkSync(filePath)
+        if (filePath) {
+          fs.unlinkSync(filePath)
+        }
+        else {
+          console.warn(`WebpackSentryPlugin: unable to delete ${name} - ` +
+            'probably the file was not created due to an error in the build')
+        }
       })
   }
 }


### PR DESCRIPTION
In some situations `existsAt` field of an asset can be `undefined`. For example it happens when some webpack loaders earlier in the build had errors.  This PR adds a check for the path to be defined before trying to delete it.

Will probably provide more info for cases like #69.