### PR TITLE
fix: unformatted webpack errors

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -122,10 +122,10 @@ module.exports = class SentryPlugin {
       this.suppressErrors ||
       (this.suppressConflictError && err.statusCode === 409)
     ) {
-      compilation.warnings.push(errorMsg)
+      compilation.warnings.push(new Error(errorMsg))
     }
     else {
-      compilation.errors.push(errorMsg)
+      compilation.errors.push(new Error(errorMsg))
     }
   }
 


### PR DESCRIPTION
Webpack compilation errors and warnings should be typed as `Error` to get a better stacktrace.
Some frameworks, like Gatsby, parse Webpack errors then fail when they encounter errors as String.